### PR TITLE
Fix image display when using default card rendering

### DIFF
--- a/src/Components/Card.jsx
+++ b/src/Components/Card.jsx
@@ -17,7 +17,7 @@ function Card(props) {
 
   importAll(require.context("../public", false, /\.(png|jpe?g|svg)$/));
   const filteredImage = Object.entries(cache).map(
-    (module) => module[1].default
+    (module) => module[1]
   );
 
   return (


### PR DESCRIPTION
# Summary of changes
Fixes image display when using the default card rendering.

# Related Issue
Cards that use default rendering (like indigos) does not display image correctly

# How to test (for features) / reproduce (for bugs)

image on card will look display properly

# Screenshots

![Screen Shot 2022-10-08 at 9 43 40 PM](https://user-images.githubusercontent.com/22737121/194736896-bea3106a-24d1-44ca-978f-b1bb4632db73.png)

# Changes include
- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation (explains but does not affect functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Notes
- please consider including a gif that reflects your feelings about this PR
